### PR TITLE
Fix Get-SqlRegisteredServerName Group Parameter Docs

### DIFF
--- a/functions/Get-SqlRegisteredServerName.ps1
+++ b/functions/Get-SqlRegisteredServerName.ps1
@@ -2,10 +2,10 @@ Function Get-SqlRegisteredServerName
 {
 <#
 .SYNOPSIS
-Gets list of SQL Server names stored in SQL Server Central Management Server
+Gets list of SQL Server names stored in SQL Server Central Management Server.
 
 .DESCRIPTION
-Returns a simple array of server names
+Returns a simple array of server names. Be aware of the dynamic parameter 'Group', which can be used to limit results to one or more groups you have created on the CMS. See get-help for examples.
 
 .PARAMETER SqlServer
 The SQL Server instance. 
@@ -22,10 +22,10 @@ Auto-populated list of groups in SQL Server Central Management Server. You can s
 By default, the Central Management Server name is included in the list. Use -NoCmsServer to exclude the CMS itself.
 	
 .PARAMETER NetBiosName
-Returns just the NetBios names of each server
+Returns just the NetBios names of each server.
 	
 .PARAMETER IpAddr
-Returns just the ip addresses of each server
+Returns just the ip addresses of each server.
 	
 .NOTES 
 dbatools PowerShell module (https://dbatools.io, clemaire@gmail.com)
@@ -58,12 +58,12 @@ Get-SqlRegisteredServerName -SqlServer sqlserver2014a -SqlCredential $credential
 Gets a list of all server names from the Central Management Server on sqlserver2014a, using SQL Authentication
 		
 .EXAMPLE 
-Get-SqlRegisteredServerName -SqlServer sqlserver2014a -Groups HR, Accounting
+Get-SqlRegisteredServerName -SqlServer sqlserver2014a -Group HR, Accounting
 	
 Gets a list of server names in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
 	
 .EXAMPLE 
-Get-SqlRegisteredServerName -SqlServer sqlserver2014a -Groups HR, Accounting -IpAddr
+Get-SqlRegisteredServerName -SqlServer sqlserver2014a -Group HR, Accounting -IpAddr
 	
 Gets a list of server IP addresses in the HR and Accounting groups from the Central Management Server on sqlserver2014a.
 	


### PR DESCRIPTION
Examples were referencing parameter 'Groups' which is incorrect - is
Group.  Web page also references this, which needs to be corrected as
well.  Group parameter is dynamic parameter which causes it to not show
in get-help or intellisense, which leaves the user in the dark.  I added
a note of this to the description.  Not sure if the dynamic parameter
not showing in get-help and intellisense can be fixed.